### PR TITLE
fix: update package data to copy JS file and add env vars to docker compose

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -74,7 +74,6 @@ docker-compose up api
 - `POST /jobs` - Create a new job
 - `GET /jobs/{job_id}` - Get job details
 - `DELETE /jobs/{job_id}` - Delete a job
-- `GET /jobs/{job_id}/logs` - Get job logs
 - `GET /labels` - List all labels
 - `POST /labels` - Create a new label
 - `PUT /labels/{label_id}` - Update a label

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       - "1337:1337"
     environment:
       - STROT_POSTGRES_HOST=postgres
+      - STROT_AWS_S3_ENDPOINT_URL=http://minio:9000
+      - STROT_ANTHROPIC_API_KEY=${STROT_ANTHROPIC_API_KEY}
     depends_on:
       postgres:
         condition: service_healthy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ include = ["strot*"]
 
 [tool.setuptools]
 include-package-data = true
-package-data = {"strot" = ["**/*.txt", "**/*.jinja"]}
+package-data = {"strot" = ["**/*.js", "**/*.jinja"]}
 
 [tool.mypy]
 files = ["strot", "api"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation by removing the entry for the `GET /jobs/{job_id}/logs` endpoint.

* **Chores**
  * Added new environment variables for S3-compatible storage and Anthropic API key to the API service configuration.
  * Updated package data settings to include JavaScript files instead of text files during build and distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->