### PR TITLE
optimize: move browser install to builder stage

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -18,9 +18,10 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 RUN uv venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 
-# Copy dependency files first for better caching
+# Copy strot package pyproject.toml and install dependencies & browser
 COPY pyproject.toml ./
-COPY api/pyproject.toml ./api/
+RUN uv pip install --no-cache-dir .
+RUN /opt/venv/bin/playwright install chromium-headless-shell
 
 # Copy strot package and install it
 COPY strot/ ./strot/
@@ -28,6 +29,7 @@ RUN uv pip install --no-cache-dir .
 
 # Install API dependencies
 WORKDIR /build/api
+COPY api/pyproject.toml ./
 RUN uv pip install --no-cache-dir .
 
 
@@ -39,17 +41,18 @@ ENV PYTHONUNBUFFERED=1 \
 
 WORKDIR /app
 
+# Copy virtual environment from builder
+COPY --from=builder /opt/venv /opt/venv
+
+# Copy browser from builder and install its dependencies
+COPY --from=builder /root/.cache/ms-playwright /root/.cache/ms-playwright
+RUN /opt/venv/bin/playwright install-deps chromium-headless-shell
+
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \
     curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-# Copy virtual environment from builder
-COPY --from=builder /opt/venv /opt/venv
-
-# Install playwright chromium headless shell only
-RUN /opt/venv/bin/playwright install --only-shell --with-deps chromium
 
 # Copy application code
 COPY api/ ./api/


### PR DESCRIPTION
Move chromium-headless-shell installation to builder stage to avoid reinstalling browser on every code change, improving build cache efficiency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Dockerfile to reorganize dependency installation steps and improve the setup process for Playwright and its browser dependencies. This may result in more reliable builds and enhanced browser support within the API service container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->