### PR TITLE
fix: check for str type before detecting multiline string

### DIFF
--- a/strot/logging/__init__.py
+++ b/strot/logging/__init__.py
@@ -133,7 +133,7 @@ class UnstructuredLoggingFormatter(logging.Formatter):
                 message_parts.append(f"{v.__class__.__name__}: {v!s}")
             elif isinstance(v, float):
                 message_parts.append(f"{k}={v:.2f}")
-            elif "\n" in v:
+            elif isinstance(v, str) and "\n" in v:
                 message_parts.append(f"{k}='''\n{v.strip("\n")}\n'''")
             else:
                 message_parts.append(f"{k}={v!r}")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging stability by preventing errors when formatting non-string values containing newline characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->