### PR TITLE
Feat: Separate Job Status Check and Data Fetching into Distinct Endpoints

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -109,10 +109,10 @@ Example:
 
 ```bash
 # Check job status
-curl GET /v1/jobs/12345678-1234-1234-1234-123456789012
+curl GET http://localhost:8000/v1/jobs/12345678-1234-1234-1234-123456789012
 
 # Fetch data with dynamic parameters
-curl -X POST /v1/jobs/12345678-1234-1234-1234-123456789012/fetch?limit=20&offset=0 \
+curl -X POST http://localhost:8000/v1/jobs/12345678-1234-1234-1234-123456789012/fetch?limit=20&offset=0 \
      -d "sortBy=price&category=electronics&brand=apple"
 ```
 

--- a/api/README.md
+++ b/api/README.md
@@ -70,15 +70,51 @@ docker-compose up api
 
 ## API Endpoints
 
+### Core
+
 - `GET /` - Health check
-- `GET /jobs` - List all jobs
+
+### Jobs
+
+- `GET /jobs` - List all jobs with pagination and filters
 - `POST /jobs` - Create a new job
-- `GET /jobs/{job_id}` - Get job details
+- `GET /jobs/{job_id}` - Get job status and source metadata (no data fetching)
+- `POST /jobs/{job_id}/fetch` - Fetch data from a ready job with limit/offset and dynamic parameters
 - `DELETE /jobs/{job_id}` - Delete a job
+
+### Labels
+
 - `GET /labels` - List all labels
 - `POST /labels` - Create a new label
 - `PUT /labels/{label_id}` - Update a label
 - `DELETE /labels/{label_id}` - Delete a label
+
+### Job Data Fetching
+
+The job endpoints are designed with separation of concerns:
+
+**Status Check:** `GET /jobs/{job_id}`
+
+- Returns job status, metadata, and source information
+- No data fetching - use this for monitoring job progress
+
+**Data Fetching:** `POST /jobs/{job_id}/fetch?limit=50&offset=0`
+
+- Fetches actual data from the discovered API
+- Supports dynamic parameters via form data (sorting, filtering, search, etc.)
+- Returns partial data even if request fails partway through
+- Response format: `{"data": [...], "error": "optional error message"}`
+
+Example:
+
+```bash
+# Check job status
+curl GET /v1/jobs/12345678-1234-1234-1234-123456789012
+
+# Fetch data with dynamic parameters
+curl -X POST /v1/jobs/12345678-1234-1234-1234-123456789012/fetch?limit=20&offset=0 \
+     -d "sortBy=price&category=electronics&brand=apple"
+```
 
 ## Database
 

--- a/eval/evaluator.py
+++ b/eval/evaluator.py
@@ -191,7 +191,7 @@ class JobEvaluator:
             if source_instance.request_detail.pagination_info:
                 pagination_keys_actual = source_instance.request_detail.pagination_info.keys
 
-            dynamic_keys_actual = source_instance.request_detail.dynamic_parameter_keys
+            dynamic_keys_actual = list(source_instance.request_detail.dynamic_parameters)
 
             pagination_keys_matching = "no"
             if expected_pagination_keys and pagination_keys_actual:
@@ -524,7 +524,7 @@ async def get_pagination_and_dynamic_parameter_keys(
     pagination_keys = []
     if request_detail.pagination_info:
         pagination_keys = request_detail.pagination_info.keys
-    return pagination_keys, request_detail.dynamic_parameter_keys
+    return pagination_keys, list(request_detail.dynamic_parameters)
 
 
 async def get_entity_count(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pillow>=11.2.1",
     "pydantic>=2.11.3",
     "python-magic>=0.4.27",
+    "python-multipart>=0.0.20",
     "rapidfuzz>=3.13.0",
     "regex>=2024.11.6",
     "rnet>=2.4.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "json-repair>=0.44.1",
     "jsonref>=1.1.0",
     "openai>=1.76.0",
-    "patchright>=1.52.5",
+    "patchright==1.52.5",
     "pillow>=11.2.1",
     "pydantic>=2.11.3",
     "python-magic>=0.4.27",

--- a/strot/pagination_translators/limit_offset.py
+++ b/strot/pagination_translators/limit_offset.py
@@ -162,7 +162,7 @@ class LimitOffsetTranslator(BasePaginationTranslator):
                     used_fallback = True
                     response = await request_detail.make_request(parameters=state)
                 else:
-                    break
+                    raise
 
             response_text = await response.text()
             # Check for identical responses (end of data)
@@ -222,10 +222,7 @@ class LimitOffsetTranslator(BasePaginationTranslator):
                 pg_info.offset.key: str(pg_info.offset.default_value + offset_within_page),
             }
 
-            try:
-                response = await request_detail.make_request(parameters=state)
-            except RequestException:
-                break
+            response = await request_detail.make_request(parameters=state)
 
             response_text = await response.text()
             if not response_text or response_text == last_response_text:

--- a/strot/schema/request/detail.py
+++ b/strot/schema/request/detail.py
@@ -15,7 +15,7 @@ __all__ = ("RequestDetail",)
 class RequestDetail(BaseSchema):
     request: Request
     pagination_info: PaginationInfo | None = None
-    dynamic_parameter_keys: list[str] = Field(default_factory=list)
+    dynamic_parameters: dict[str, Any] = Field(default_factory=dict)
     code_to_apply_parameters: str | None = None
 
     _client: rnet.Client | None = PrivateAttr(default=None)

--- a/strot/schema/source.py
+++ b/strot/schema/source.py
@@ -14,8 +14,8 @@ class Source(BaseSchema):
         unknown = set(dynamic_parameters) - set(self.request_detail.dynamic_parameters)
         if unknown:
             raise ValueError(
-                f"Unknown dynamic parameter(s): {", ".join(sorted(unknown))}. "
-                f"Allowed: {", ".join(sorted(self.request_detail.dynamic_parameters))}"
+                f'Unknown dynamic parameter(s): {", ".join(sorted(unknown))}. '
+                f'Allowed: {", ".join(sorted(self.request_detail.dynamic_parameters))}'
             )
 
         if limit < 0 or offset < 0:

--- a/strot/schema/source.py
+++ b/strot/schema/source.py
@@ -11,11 +11,11 @@ class Source(BaseSchema):
     response_detail: ResponseDetail
 
     async def generate_data(self, *, limit: int, offset: int, **dynamic_parameters):
-        unknown = set(dynamic_parameters) - set(self.request_detail.dynamic_parameter_keys)
+        unknown = set(dynamic_parameters) - set(self.request_detail.dynamic_parameters)
         if unknown:
             raise ValueError(
                 f"Unknown dynamic parameter(s): {", ".join(sorted(unknown))}. "
-                f"Allowed: {", ".join(sorted(self.request_detail.dynamic_parameter_keys))}"
+                f"Allowed: {", ".join(sorted(self.request_detail.dynamic_parameters))}"
             )
 
         if limit < 0 or offset < 0:
@@ -43,7 +43,7 @@ class OldSource(BaseSchema):
         request_detail = RequestDetail(
             request=self.request,
             pagination_info=self.pagination_strategy,
-            dynamic_parameter_keys=[],  # Old source didn't support dynamic parameters
+            dynamic_parameters={},  # Old source didn't support dynamic parameters
             code_to_apply_parameters=None,  # Use fallback parameter application
         )
 

--- a/ui/src/components/views/FullPageJobView.tsx
+++ b/ui/src/components/views/FullPageJobView.tsx
@@ -421,9 +421,13 @@ export function FullPageJobView({
                                   </svg>
                                 </div>
                                 <div className="ml-3">
-                                  {!sampleData.data && (
+                                  {sampleData.data.length > 0 ? (
                                     <h3 className="text-sm font-medium text-red-800">
                                       Partial Data Retrieved
+                                    </h3>
+                                  ) : (
+                                    <h3 className="text-sm font-medium text-red-800">
+                                      Data fetch failed
                                     </h3>
                                   )}
                                   <div className="mt-2 text-sm text-red-700">

--- a/ui/src/lib/api-client.ts
+++ b/ui/src/lib/api-client.ts
@@ -24,13 +24,12 @@ class APIClient {
   ): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
 
-    const response = await fetch(url, {
-      headers: {
-        "Content-Type": "application/json",
-        ...options.headers,
-      },
-      ...options,
-    });
+    const isFormData = options.body instanceof FormData;
+    const headers: HeadersInit = {
+      ...(isFormData ? {} : { "Content-Type": "application/json" }),
+      ...options.headers,
+    };
+    const response = await fetch(url, { ...options, headers });
 
     if (!response.ok) {
       let errorMessage = `HTTP ${response.status}: ${response.statusText}`;

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -39,7 +39,6 @@ export interface GetJobResponse {
   completed_at?: string;
   error?: string;
   source?: any;
-  result?: any;
 }
 
 // Label related types

--- a/uv.lock
+++ b/uv.lock
@@ -1526,7 +1526,7 @@ wheels = [
 
 [[package]]
 name = "strot"
-version = "1.2.0.post33.dev0+3dc2519"
+version = "1.2.0.post37.dev0+3474ebe"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -1576,7 +1576,7 @@ requires-dist = [
     { name = "json-repair", specifier = ">=0.44.1" },
     { name = "jsonref", specifier = ">=1.1.0" },
     { name = "openai", specifier = ">=1.76.0" },
-    { name = "patchright", specifier = ">=1.52.5" },
+    { name = "patchright", specifier = "==1.52.5" },
     { name = "pillow", specifier = ">=11.2.1" },
     { name = "pydantic", specifier = ">=2.11.3" },
     { name = "python-magic", specifier = ">=0.4.27" },

--- a/uv.lock
+++ b/uv.lock
@@ -1110,6 +1110,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546 },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1517,7 +1526,7 @@ wheels = [
 
 [[package]]
 name = "strot"
-version = "1.1.0.post2.dev0+3082625"
+version = "1.2.0.post33.dev0+3dc2519"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -1533,6 +1542,7 @@ dependencies = [
     { name = "pillow" },
     { name = "pydantic" },
     { name = "python-magic" },
+    { name = "python-multipart" },
     { name = "rapidfuzz" },
     { name = "regex" },
     { name = "rnet" },
@@ -1570,6 +1580,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=11.2.1" },
     { name = "pydantic", specifier = ">=2.11.3" },
     { name = "python-magic", specifier = ">=0.4.27" },
+    { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "rapidfuzz", specifier = ">=3.13.0" },
     { name = "regex", specifier = ">=2024.11.6" },
     { name = "rnet", specifier = ">=2.4.2" },


### PR DESCRIPTION
This PR refactors the job endpoints to follow REST principles by separating job status checking from data fetching operations.
Previously, the GET /jobs/{job-id} endpoint handled both status retrieval and optional data fetching, creating API confusion and tight coupling.

🎯 Changes Made

API Backend (`api/strot_api/routes/jobs.py`)

- Modified `GET /jobs/{job-id}`: Now only returns job status, metadata, and source information (removed limit/offset params and result field)
- Added `POST /jobs/{job-id}/fetch`: New dedicated endpoint for data fetching with:
  - Query parameters: limit and offset for pagination
  - Form data: Dynamic parameters (sorting, filtering, search, etc.)
  - Graceful error handling: Returns partial data + error message instead of throwing HTTP 400
- Updated response models:
  - `GetJobResponse`: Removed result field
  - `FetchDataResponse`: Added optional error field for partial failure scenarios

Evaluation System (`eval/client.py`)

- Updated `fetch_data()` method to use `POST /jobs/{job-id}/fetch` endpoint
- Added support for dynamic parameters via form data
- Updated response parsing to handle new `{"data": [...]}` format

UI System

- API Client (`ui/src/lib/api-client.ts`):
  - Simplified `getJob()` to only fetch status (removed limit/offset params)
  - Removed `getJobWithSampleData()` method
  - Added `fetchJobData()` method for the new POST endpoint with dynamic parameter support
- UI Components (`ui/src/components/views/FullPageJobView.tsx`):
  - Updated to use separate status checking and data fetching calls
  - Enhanced error handling UI to show partial data with error messages
  - Updated `cURL` command generation for new POST endpoint
- Type Definitions (`/src/types/index.ts`): Removed result field from `GetJobResponse`

Documentation (`api/README.md`)

- Updated API documentation with clear separation of concerns
- Added detailed examples for both status checking and data fetching
- Documented dynamic parameter usage and error handling

📊 API Changes

Before:

# Status + Data in one call (confusing)
`GET /v1/jobs/{job-id}?limit=50&offset=0`

After:

# Separate, clear operations
```
GET /v1/jobs/{job-id}                              # Status only
POST /v1/jobs/{job-id}/fetch?limit=50&offset=0     # Data fetching
  -d "sortBy=price&category=electronics"
```
🧪 Backward Compatibility

- ✅ GET `/jobs/{job-id}` continues to work (just returns different fields)
- ✅ All existing job status monitoring functionality preserved
- ✅ Data fetching now uses dedicated endpoint with enhanced capabilities

🔍 Testing

- Eval system compatibility verified
- UI functionality tested with new endpoints
- Error handling scenarios validated
- Dynamic parameter support confirmed
- Partial data retrieval working as expected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added POST /jobs/{job_id}/fetch for paginated data retrieval with dynamic parameters.
  - Labels endpoints added; GET /jobs supports pagination and filters.
  - UI preview tab shows sample data and reports partial-data errors.

- Refactor
  - GET /jobs/{job_id} now returns status and metadata only (no data payload).
  - Client and UI updated to use the new fetch endpoint and response shape.
  - Pagination errors now propagate to callers.

- Documentation
  - API docs reorganized (Core, Jobs, Labels, Job Data Fetching) with curl examples.

- Chores
  - Added python-multipart dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->